### PR TITLE
harden: github actions step uses a mutable tag or branc... in...

### DIFF
--- a/.github/oldworkflows/main.yml
+++ b/.github/oldworkflows/main.yml
@@ -20,29 +20,29 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2.7.0
 
       # Set up the Java environment
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381f1c1e99d49  # v1.4.4
         with:
           java-version: 1.8
 
       # Kick off JBake and bake
-      - uses: eskatos/gradle-command-action@v1
+      - uses: eskatos/gradle-command-action@d42b89ae1dc7ee62c9a86bb51b13fbd0c4cae5f4  # v1.3.3
         with:
           arguments: bake
 
       # Log in to Azure
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a  # v1.4.6
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
           allow-no-subscriptions: true
       
       # Batch-upload the output/ contents
       - name: Azure CLI script
-        uses: azure/CLI@v1
+        uses: azure/CLI@b143de62e0cbf4cde59da2a04e7b9880c2e0c86a  # v1.0.9
         with:
           inlineScript: |
             az storage blob upload-batch --overwrite -s $GITHUB_WORKSPACE/build/output -d \$web --connection-string "DefaultEndpointsProtocol=https;AccountName=researchstorage;AccountKey=${{ secrets.AZURE_LICENSE_KEY }};EndpointSuffix=core.windows.net"


### PR DESCRIPTION
## Summary
Harden input handling in `.github/oldworkflows/main.yml` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `yaml.github-actions.security.github-actions-mutable-action-tag.github-actions-mutable-action-tag` |
| **File** | `.github/oldworkflows/main.yml:23` |
| **Assessment** | Defensive hardening |

**Description**: GitHub Actions step uses a mutable tag or branch reference. Tags and branch names can be silently repointed by the action owner, enabling supply-chain attacks — as seen in the trivy-action and kics-github-action compromises. Pin the reference to a full 40-character commit SHA instead, e.g. `uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608`.

## Changes
- `.github/oldworkflows/main.yml`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
